### PR TITLE
Update based on Nguyen et al 2023

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -97,11 +97,15 @@ fn solve(solve_opts: SolveOpts) -> Result<(), Box<dyn std::error::Error>> {
     let (var_mapping, normalized_formula) = normalize_cnf_variables(&formula);
 
     println!("Simulating...");
+    let mut rng = rand::thread_rng();
     let mut state = State {
-        v: Array1::zeros(normalized_formula.varnum),
-        xs: Array1::zeros(normalized_formula.clauses.len()),
+        v: Array1::from_iter(
+            (0..normalized_formula.varnum).map(|_| rng.gen::<f64>() * 2.0 - 1.0),
+        ),
+        xs: init_short_term_memory(&formula),
         xl: Array1::ones(normalized_formula.clauses.len()),
     };
+
     let result = simulate(
         &mut state,
         &normalized_formula,
@@ -165,7 +169,7 @@ fn batch(batch_opts: BatchOpts) -> Result<(), Box<dyn std::error::Error>> {
             v: Array1::from_iter(
                 (0..normalized_formula.varnum).map(|_| rng.gen::<f64>() * 2.0 - 1.0),
             ),
-            xs: Array1::zeros(normalized_formula.clauses.len()),
+            xs: init_short_term_memory(&formula),
             xl: Array1::ones(normalized_formula.clauses.len()),
         };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,9 +99,7 @@ fn solve(solve_opts: SolveOpts) -> Result<(), Box<dyn std::error::Error>> {
     println!("Simulating...");
     let mut rng = rand::thread_rng();
     let mut state = State {
-        v: Array1::from_iter(
-            (0..normalized_formula.varnum).map(|_| rng.gen::<f64>() * 2.0 - 1.0),
-        ),
+        v: Array1::from_iter((0..normalized_formula.varnum).map(|_| rng.gen::<f64>() * 2.0 - 1.0)),
         xs: init_short_term_memory(&formula),
         xl: Array1::ones(normalized_formula.clauses.len()),
     };

--- a/src/system.rs
+++ b/src/system.rs
@@ -204,7 +204,9 @@ pub fn simulate(
 
 // The initial short term memories; values if all variables are 0.
 pub fn init_short_term_memory(formula: &CNFFormula) -> Array1<f64> {
-    let clause_values: Vec<f64> = formula.clauses.iter()
+    let clause_values: Vec<f64> = formula
+        .clauses
+        .iter()
         .map(|clause| {
             if clause.literals.iter().any(|literal| literal.is_negated) {
                 1.0
@@ -213,6 +215,6 @@ pub fn init_short_term_memory(formula: &CNFFormula) -> Array1<f64> {
             }
         })
         .collect();
-    
+
     Array1::from(clause_values)
 }


### PR DESCRIPTION
This folds in changes from the paper `Hardware implementation of digital memcomputing on small-size FPGAs`. This paper includes some changes to the system presented in previous papers; most notably the bounds on short-term memory are changed from [0, 1] to [ϵ, 1-ϵ]. Less notable are some changes to initialization.

This has led to a general increase in capabilities I've noticed in testing. Some previous problems are solved noticeably faster and, most significantly, many problems that were previously unsolvable (for example, aim-50-1_6-yes1-1, which previously could not be solved, with or without batching after several hours) are now solvable.