### PR TITLE
Implement elimination by clause distribution based preprocessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,15 @@ One can also run in batch mode. And, instead of specifying a tolerance for the a
 ```
 cargo run batch -f tests/easy.cnf -n 1000 -b 100 -s 0.01 -o tests/out
 ```
+
+One can also run batches of simulations interlaced using `inter`.
+
+```
+cargo run inter -f tests/easy.cnf -n 1000 -b 100 -s 0.01 -o tests/out
+```
+
+Additionally, `solve` will preprocess the formula until it has a desired clause-to-variable ratio. This is specified with `-r`, and defaults to 7. This is necessary to solve cnfs with a low (~2) clause to variable ratio.
+
+```
+cargo run solve -f tests/easy.cnf -o tests/out -r 6
+```

--- a/src/system.rs
+++ b/src/system.rs
@@ -356,7 +356,6 @@ pub fn simulate_inter(
     } else {
         states[0].v.iter().map(|&value| value > 0.0).collect()
     }
-
 }
 
 // The initial short term memories; values if all variables are 0.


### PR DESCRIPTION
This substantially increases the reliability of finding a solution for cnfs with a small clause-to-variable ratio. By default, ODESAT has trouble with such problems because they have low topological connectedness. This implements a simple heuristic where the variables which occur in the smallest number of clauses are eliminated using clause distribution until the clause-to-variable ratio reaches a desired level, specified with `-r`. r defaults to 7, but this isn't necessarily optimal.